### PR TITLE
Adding missing test dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,4 @@ TEST =  pydocstyle>=6.1.1
         pytest-mockito>=0.0.4
         pytest-cov>=3.0.0
         black
+        pydocstyle


### PR DESCRIPTION
CI build was failing due to pydocstyle being missing.